### PR TITLE
Ajuste sei 5.0 oracle

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 
-# Módulo de Integração SEI & FalaBRxxxxx
+# Módulo de Integração SEI & FalaBR
 
 ## Requisitos
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 
-# Módulo de Integração SEI & FalaBR
+# Módulo de Integração SEI & FalaBRxxxxx
 
 ## Requisitos
 

--- a/sei/scripts/md_cgu_eouv_atualizar_modulo.php
+++ b/sei/scripts/md_cgu_eouv_atualizar_modulo.php
@@ -105,9 +105,9 @@ class MdCguEouvAtualizadorSeiRN extends InfraScriptVersao
     $objInfraParametro->setValor('ID_SERIE_EXTERNO_OUVIDORIA', '92');
     $objInfraParametro->setValor('EOUV_ID_SERIE_DOCUMENTO_EXTERNO_DADOS_MANIFESTACAO', '63');
     $objInfraParametro->setValor('EOUV_DATA_INICIAL_IMPORTACAO_MANIFESTACOES ', date('d/m/Y'));
-    $objInfraParametro->setValor('EOUV_URL_DETALHE_MANIFESTACAO', '');
-    $objInfraParametro->setValor('EOUV_USUARIO_ACESSO_WEBSERVICE', '');
-    $objInfraParametro->setValor('EOUV_SENHA_ACESSO_WEBSERVICE', '');
+    $objInfraParametro->setValor('EOUV_URL_DETALHE_MANIFESTACAO', 'XXX');
+    $objInfraParametro->setValor('EOUV_USUARIO_ACESSO_WEBSERVICE', 'XXX');
+    $objInfraParametro->setValor('EOUV_SENHA_ACESSO_WEBSERVICE', 'XXX');
 
     $this->logar('Criando Agendamento da tarefa no SEI');
     $objInfraAgendamentoTarefaDTO = new InfraAgendamentoTarefaDTO();


### PR DESCRIPTION
Na instalação do módulo em banco Oracle, ocorre erro porque a tabela "md_eouv_parametros" não permite valores NULL na coluna "de_valor_parametro", mas o processo de gravação está tentando inserir esse valor nulo.